### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ impl Display for Color {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
-            "RGB ({0}, {1}, {2}) 0x{0:02.X}{1:02.X}{2:02.X}",
+            "RGB ({0}, {1}, {2}) 0x{0:02X}{1:02X}{2:02X}",
             self.red, self.green, self.blue
         )
     }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.